### PR TITLE
Tapestry integration fixes: ASM 9.9, enum-receiver guard (#5), ReentrantLock stripe

### DIFF
--- a/crochet-agent/src/main/java/net/jonbell/crochet/runtime/CheckpointRollbackAgent.java
+++ b/crochet-agent/src/main/java/net/jonbell/crochet/runtime/CheckpointRollbackAgent.java
@@ -250,6 +250,41 @@ public final class CheckpointRollbackAgent {
      * user-classes-touched-so-far. Callers with their own static root
      * collections should checkpoint those explicitly before or after.
      *
+     * <p><b>What gets snapped per class</b>: the <em>reference values</em>
+     * of each user class's mutable non-final static fields (see
+     * {@link net.jonbell.crochet.transform.StaticFieldHelperTemplate}).
+     * {@code checkpointAll} does <em>not</em> transitively snapshot the
+     * state of objects those static references point at — the per-object
+     * snapshot in {@link CRIJInstrumented} fires only when the object's
+     * klass has been swapped to a Fast proxy, which
+     * {@link #checkpoint(Object)} does explicitly. If your program mutates
+     * fields of an object reachable through a static reference and expects
+     * {@code rollbackAll} to reverse those mutations, you must
+     * <em>also</em> call {@link #checkpoint(Object)} on that referent (or
+     * annotate/opt-in via {@link CrochetEager} so its static initialiser
+     * captures one proactively). {@code rollbackAll} only restores the
+     * static field's reference slot; the referent's internal fields stay
+     * at their post-mutation values.
+     *
+     * <p><b>One-shot per checkpoint phase</b>: like all per-target
+     * {@link #checkpoint(Object)} calls, each {@code checkpointAll()} /
+     * {@code rollbackAll(v)} pair corresponds to one version bump — after
+     * rolling back to version {@code v} the registered snapshots are
+     * consumed. Code that wants to roll back to the same logical state
+     * multiple times must take a fresh checkpoint after each rollback:
+     * <pre>
+     *   int v = checkpointAll();
+     *   for (int i = 0; i &lt; N; i++) {
+     *     mutate();
+     *     rollbackAll(v);
+     *     v = checkpointAll(); // re-checkpoint between iterations
+     *   }
+     * </pre>
+     * This matches the paper's flat-nested semantics (§3.1): a second
+     * checkpoint discards the first, and rollback restores to the most
+     * recent checkpoint only. The same rule applies to the per-object API
+     * (see demo scenario 05-rollback-then-checkpoint).
+     *
      * <p><b>Escape hatch</b>: {@code -Dcrochet.checkpointAll.skipSystem=true}
      * elides the thread-list and classloader walks.
      */

--- a/crochet-agent/src/main/java/net/jonbell/crochet/runtime/FastAccessCoordinator.java
+++ b/crochet-agent/src/main/java/net/jonbell/crochet/runtime/FastAccessCoordinator.java
@@ -1,5 +1,7 @@
 package net.jonbell.crochet.runtime;
 
+import java.util.concurrent.locks.ReentrantLock;
+
 /**
  * Race-winner coordinator for {@link CheckpointRollbackAgent#fastAccess}.
  *
@@ -15,14 +17,48 @@ package net.jonbell.crochet.runtime;
  * dropping contention from O(threads) to O(threads / stripes) on typical
  * workloads.
  *
+ * <p><b>Stripe-lock primitive: {@link ReentrantLock}, NOT JVM monitor</b>
+ * (Tapestry stripefix). This coordinator <em>used to</em> hand out plain
+ * {@code Object} stripes for callers to {@code synchronized(stripe) { ... }}
+ * over. That worked fine for plain Crochet but deadlocked when stacked under
+ * Fray: the {@code monitorenter} bytecode in {@link FastProxySupport#fastAccess}
+ * was emitted before Fray's instrumentation agent registered (Crochet's premain
+ * forces {@code FastProxySupport} / {@code FastAccessCoordinator} to load
+ * eagerly via {@link CheckpointRollbackAgent#setInstrumentation}, which
+ * happens at {@code -javaagent:crochet.jar} install time — strictly earlier
+ * than Fray's {@code -javaagent:fray.jar} can wire in its
+ * {@code MonitorInstrumenter}). Once a class is loaded its bytecode is fixed:
+ * Fray's premain calls {@code addTransformer} but never
+ * {@code retransformClasses}, so already-loaded Crochet classes never get
+ * their monitorenter wrapped with {@code Runtime.onMonitorEnter}. Fray's
+ * scheduler then can't see contention on the stripe — Thread A acquires
+ * (uninstrumented JVM monitor), yields to scheduler (Fray-park), Thread B
+ * tries to acquire (uninstrumented JVM monitor → JVM-level BLOCKED outside
+ * Fray's bookkeeping), Fray sees no runnable thread and the test deadlocks.
+ *
+ * <p>{@link ReentrantLock} side-steps this: its lock body lives in
+ * {@code java.util.concurrent.locks} (in {@code java.base}), gets
+ * jlink-time-instrumented by Fray's {@code JlinkPlugin} when the
+ * {@code java-inst} JDK is built, and the contended path runs through
+ * {@link java.util.concurrent.locks.LockSupport#park()} — which Fray's
+ * {@code LockSupportInstrumenter} explicitly wraps with
+ * {@code Runtime.onLockAcquire} / {@code Runtime.onThreadUnpark}. So
+ * Fray's scheduler sees both the lock acquire and any blocking on it,
+ * and the thread that holds the lock is properly accounted as "owns
+ * resource X". Whether Fray runs at all or the lock is uncontended, the
+ * fast path is still a single CAS on AQS state — no observable perf
+ * difference vs the synchronized form on plain Crochet (a microbench
+ * agreed to within a few ns/op on the contended path; uncontended is
+ * identical because both reduce to a single CAS).
+ *
  * <p><b>Padding</b>: each stripe is a {@link Stripe} instance whose class
  * carries {@link jdk.internal.vm.annotation.Contended @Contended}, which HotSpot
  * honors by inserting 128 bytes of padding before and after instance fields,
  * pushing each stripe onto its own cache line (two lines, actually — HotSpot
  * uses double-wide padding for the prefetcher). This is the standard recipe
  * Doug Lea uses in {@code Striped64} and {@code ForkJoinPool} to keep
- * neighboring stripes from false-sharing the monitor-inflation bits. The
- * runtime is packed into {@code java.base} so the annotation resolves
+ * neighboring stripes from false-sharing the AQS state word and waiter list.
+ * The runtime is packed into {@code java.base} so the annotation resolves
  * without {@code -XX:-RestrictContended}.
  *
  * <p><b>Dynamic count</b>: stripes sized to {@code 2^ceil(log2(4 * availableProcessors()))}
@@ -38,9 +74,10 @@ package net.jonbell.crochet.runtime;
  *       {@link CheckpointRollbackAgent#nextRollbackVersion}. The stripe lock
  *       has no bearing on version uniqueness.
  *   <li><b>I2 (monotone)</b>: the stripe lock's release-acquire edge gives the
- *       same happens-before guarantee as the old per-class lock: any thread
- *       that acquires the same stripe observes the winner's published snap +
- *       klass swap.
+ *       same happens-before guarantee as the old per-class lock — and is
+ *       preserved by {@link ReentrantLock} (its lock/unlock pair establishes
+ *       the same happens-before edge as enter/exit on a JVM monitor: see
+ *       {@link java.util.concurrent.locks.Lock} javadoc and JLS §17.4.5).
  *   <li><b>Sentinel {@code -v} semantics</b>: sentinel install is done in
  *       {@code $$crochetCheckpoint} / {@code $$crochetRollback} via
  *       {@link CheckpointRollbackAgent#versionCas}, independent of this
@@ -103,24 +140,45 @@ final class FastAccessCoordinator {
     }
 
     /**
-     * Padded stripe wrapper. The monitor is on {@code this}; the class body
-     * carries no fields — padding comes from {@link jdk.internal.vm.annotation.Contended}
-     * which HotSpot interprets even on a field-less class by inserting
-     * pre/post padding regions in the object layout. Runtime is packed into
-     * {@code java.base} so access to the {@code jdk.internal.vm.annotation}
-     * package is granted without {@code -XX:-RestrictContended}.
+     * Padded stripe wrapper that owns a {@link ReentrantLock}. Callers
+     * acquire via {@link Stripe#lock} and release in a finally block — see
+     * the call site in {@link FastProxySupport#fastAccess} for the
+     * try/finally shape.
+     *
+     * <p>The lock-routing change (synchronized → ReentrantLock) is what makes
+     * this safe to compose under Fray's scheduler — see the class javadoc for
+     * the deadlock mechanism that motivated it. A {@link ReentrantLock} is
+     * also reentrant in the same way the JVM monitor was, so any nested
+     * fastAccess re-entry on the same stripe (which Crochet's
+     * {@code $$crochetPropagateCheckpoint} / propagate-rollback paths can
+     * trigger when chains of objects share a stripe by hash collision) still
+     * works.
+     *
+     * <p>Padding still comes from {@link jdk.internal.vm.annotation.Contended}.
+     * On a {@code @Contended} class HotSpot pads around <em>every</em>
+     * declared field with cache-line gaps, so the {@code lock} reference
+     * (and the AQS state word the {@link ReentrantLock} indirects to) sits
+     * on its own cache line, defusing false sharing between adjacent stripes.
      */
     @jdk.internal.vm.annotation.Contended
-    private static final class Stripe {
-        Stripe() {}
+    static final class Stripe {
+        final ReentrantLock lock;
+        Stripe() {
+            // Non-fair lock: matches the historical synchronized monitor's
+            // unfair handoff (HotSpot biased/inflated monitors are not FIFO).
+            // Fair locks are O(N) more expensive on the contended path and
+            // we have no fairness requirement at this level — the work
+            // executed under the lock is short and order-independent.
+            this.lock = new ReentrantLock(false);
+        }
     }
 
     /**
-     * Return a stable stripe-lock for {@code obj}. Callers should
-     * {@code synchronized(lockFor(obj)) { ... }} around the snapshot/restore
-     * body inside {@link CheckpointRollbackAgent#fastAccess}.
+     * Return a stable stripe-lock holder for {@code obj}. The caller should
+     * acquire {@code stripe.lock.lock()} / release in finally — see
+     * {@link FastProxySupport#fastAccess} for the canonical call shape.
      */
-    static Object lockFor(Object obj) {
+    static Stripe lockFor(Object obj) {
         // identityHashCode may allocate a hash on first call, but the result
         // is stable for the object's lifetime per JLS §15.8.2. Some JVMs show
         // biased low bits for fresh objects in the same TLAB (especially on

--- a/crochet-agent/src/main/java/net/jonbell/crochet/runtime/FastProxySupport.java
+++ b/crochet-agent/src/main/java/net/jonbell/crochet/runtime/FastProxySupport.java
@@ -346,12 +346,26 @@ final class FastProxySupport {
         // the previous synchronized(userClass) which serialized across all
         // instances of the same class. See FastAccessCoordinator javadoc for
         // the invariant-preservation argument (I1, I2, sentinel handling).
-        Object stripe = FastAccessCoordinator.lockFor(obj);
-        synchronized (stripe) {
+        //
+        // Tapestry stripefix: the stripe acquire is a ReentrantLock, NOT a
+        // JVM-level synchronized block. The synchronized form deadlocked when
+        // Crochet was layered under Fray's scheduler — Crochet's premain
+        // forces FastProxySupport / FastAccessCoordinator to load before
+        // Fray's transformer registers, so the bytecode's monitorenter never
+        // got wrapped with Fray's scheduling hook. ReentrantLock routes the
+        // contended path through LockSupport.park (in java.base, transformed
+        // by Fray's JlinkPlugin at the time the instrumented JDK is built),
+        // which Fray's scheduler does see. See FastAccessCoordinator javadoc
+        // for the full mechanism + correctness argument; from the lock
+        // semantics side this swap is happens-before equivalent (JLS §17.4.5).
+        FastAccessCoordinator.Stripe stripe = FastAccessCoordinator.lockFor(obj);
+        stripe.lock.lock();
+        try {
             // Re-check under the lock: a peer may have won the klass CAS
             // while we were blocked acquiring the stripe, in which case the
             // work is done and we just return. Happens-before is established
-            // by the stripe monitor's release-acquire.
+            // by the stripe lock's release-acquire pair (ReentrantLock
+            // unlock/lock has the same memory semantics as monitorexit/enter).
             if (!CRIJFast.class.isAssignableFrom(obj.getClass())) {
                 return;
             }
@@ -398,9 +412,11 @@ final class FastProxySupport {
                 throw new RollbackException(RollbackException.POISON_VERSION, t);
             }
             // Work done: CAS klass proxy→user. This is the race-winner
-            // transition — any peer still blocked on the stripe monitor will
+            // transition — any peer still blocked on the stripe lock will
             // re-check CRIJFast after release and return cheaply.
             swapKlassProxyToUser(obj, userClass);
+        } finally {
+            stripe.lock.unlock();
         }
     }
 

--- a/crochet-agent/src/main/java/net/jonbell/crochet/transform/CrochetTransformer.java
+++ b/crochet-agent/src/main/java/net/jonbell/crochet/transform/CrochetTransformer.java
@@ -124,7 +124,7 @@ public class CrochetTransformer {
         chain = new ArrayAccessWrapper(Opcodes.ASM9, chain, locals);
         chain = new StaticFieldRewriter(Opcodes.ASM9, chain, loader);
         chain = new ArrayCopyInterceptor(Opcodes.ASM9, chain);
-        chain = new FieldAccessWrapper(Opcodes.ASM9, chain, locals);
+        chain = new FieldAccessWrapper(Opcodes.ASM9, chain, locals, loader);
         // ReflectionRewriter sits at the top of the user-class chain.
         // It only rewrites INVOKEVIRTUAL/INVOKESTATIC on specific
         // reflection APIs into INVOKESTATIC helpers in ReflectionFilter,

--- a/crochet-agent/src/main/java/net/jonbell/crochet/transform/FieldAccessWrapper.java
+++ b/crochet-agent/src/main/java/net/jonbell/crochet/transform/FieldAccessWrapper.java
@@ -1,6 +1,9 @@
 package net.jonbell.crochet.transform;
 
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -23,6 +26,28 @@ import org.objectweb.asm.Type;
  * <p>See {@link WrapAccessesMV#emitPreHook} for the emit-shape design
  * rationale (INVOKEVIRTUAL vs INVOKESTATIC-with-instanceof trade-off).
  *
+ * <p><b>Skipped-owner guard (gmu-swe/crochet#5)</b>: {@link CrochetTransformer}
+ * skips classes flagged {@code ACC_ENUM} / {@code ACC_INTERFACE} /
+ * {@code ACC_ANNOTATION} / {@code ACC_MODULE} (and direct enum-constant
+ * subclasses whose super is {@code java/lang/Enum}) because the JVM rejects
+ * instance-field/method injection on those forms. But field reads/writes on a
+ * receiver of one of those static types still get wrapped here — without care,
+ * the emitted {@code INVOKEVIRTUAL fOwner.$$crochetAccess()V} fails to link at
+ * runtime ({@code NoSuchMethodError}). When {@code fOwner} resolves to one of
+ * those skipped forms via {@link #ownerIsSuspicious}, we emit the guarded
+ * form instead: {@code DUP / INSTANCEOF CRIJInstrumented / IFEQ skip /
+ * INVOKEINTERFACE $$crochetAccess / GOTO end / skip: POP / end:}. The guard is
+ * elided for all other owners to preserve the fast path (see the perf trade-
+ * off note on {@link WrapAccessesMV#emitPreHook}).
+ *
+ * <p>Resolution uses {@link ClassLoader#getResourceAsStream} to read the
+ * target class file's modifier bits without triggering a recursive
+ * {@link Class#forName} from inside the transformer chain. {@code forName}
+ * during transform either bypasses our own transformer for the recursively-
+ * loaded inner class (so the inner class never gets {@code $$crochetAccess}
+ * injected — which then breaks every subsequent field access on it) or
+ * deadlocks on the loader monitor.
+ *
  * <p>{@code <clinit>} takes the full skip — static initialisers are special
  * because our own {@code $$crochet*} field initialisers would recurse into
  * the static rewriter. {@code <init>} is handled via
@@ -32,13 +57,43 @@ import org.objectweb.asm.Type;
  */
 public final class FieldAccessWrapper extends ClassVisitor {
 
+    /**
+     * Internal name of the marker interface whose instances accept
+     * {@code $$crochetAccess()}. Used by the guarded emit shape below and by
+     * the {@link #ownerIsSuspicious} resolver to decide when to emit it.
+     */
+    static final String INSTRUMENTED_INTERNAL = "net/jonbell/crochet/runtime/CRIJInstrumented";
+
+    /**
+     * Per-owner-name cache of "is this fOwner a type that cannot host an
+     * instance {@code $$crochetAccess} method?" (i.e. interface / enum /
+     * annotation / module / direct enum-constant subclass). Populated by
+     * {@link #ownerIsSuspicious}; keyed by internal name only because the
+     * answer doesn't change with loader (the class file's own modifier bits
+     * are the source of truth). Entries are {@code Boolean.TRUE} (skipped
+     * form — emit the guard), {@code Boolean.FALSE} (ordinary class — emit
+     * the direct {@code INVOKEVIRTUAL}), or absent (not yet resolved — try
+     * again next call). We never cache a "lookup failed" outcome because a
+     * later transform-time call may see the class loaded in a different
+     * loader.
+     */
+    private static final ConcurrentHashMap<String, Boolean> OWNER_SUSPECT_CACHE =
+            new ConcurrentHashMap<>();
+
     private final SharedLocalsProvider locals;
+    private final ClassLoader loader;
     private String className;
     private String superName;
 
     public FieldAccessWrapper(int api, ClassVisitor delegate, SharedLocalsProvider locals) {
+        this(api, delegate, locals, null);
+    }
+
+    public FieldAccessWrapper(int api, ClassVisitor delegate, SharedLocalsProvider locals,
+                              ClassLoader loader) {
         super(api, delegate);
         this.locals = locals;
+        this.loader = loader;
     }
 
     @Override
@@ -60,21 +115,154 @@ public final class FieldAccessWrapper extends ClassVisitor {
             return base;
         }
         boolean isCtor = "<init>".equals(name);
-        return new WrapAccessesMV(api, base, locals, className, superName, isCtor);
+        return new WrapAccessesMV(api, base, locals, className, superName, isCtor, loader);
+    }
+
+    /**
+     * Returns {@code true} when {@code fOwner} is statically known to be a
+     * type {@link CrochetTransformer#transform} skips — i.e. it cannot carry
+     * an instance {@code $$crochetAccess} method.
+     *
+     * <p>Resolution reads the class file via
+     * {@link ClassLoader#getResourceAsStream} and parses only the access
+     * flags + super name (no class loading). Critically, this avoids
+     * {@link Class#forName}: calling {@code Class.forName} from inside our
+     * own {@code ClassFileTransformer} chain triggers a recursive load of
+     * the target class. The JVM detects the reentrancy and either bypasses
+     * our transformer for the inner load (so the inner class never gets
+     * {@code $$crochetAccess} injected) or deadlocks on the loader monitor.
+     * Resource-stream parsing reads the same on-disk class bytes that the
+     * loader would later hand to our transformer, but doesn't materialise
+     * the class.
+     *
+     * <p>The classification mirrors {@link CrochetTransformer#transform}'s
+     * skip flags: {@code ACC_INTERFACE}, {@code ACC_ENUM},
+     * {@code ACC_ANNOTATION}, {@code ACC_MODULE}, plus the
+     * "extends java/lang/Enum directly" form for enum-constant subclasses.
+     * Abstract classes are NOT included — the transformer happily injects
+     * {@code $$crochetAccess} into abstract user classes (their concrete
+     * subclasses inherit it, and any direct field access on an abstract
+     * receiver's instance fields is well-defined).
+     *
+     * <p>If the class file isn't resolvable through any loader we can see
+     * (e.g. it's a runtime-defined hidden class with no {@code .class}
+     * resource), we return {@code false} — the direct {@code INVOKEVIRTUAL}
+     * is retained, matching the pre-fix behaviour. The cache populates on
+     * the first successful lookup so subsequent callers benefit; we never
+     * cache a "lookup failed" outcome because a later loader may make the
+     * class file visible.
+     */
+    static boolean ownerIsSuspicious(ClassLoader loader, String fOwner) {
+        if (fOwner == null) {
+            return false;
+        }
+        // Our own runtime classes never appear as fOwner here (shouldWrap
+        // excludes them). java.lang.Object cannot be the field owner of a
+        // GETFIELD/PUTFIELD anyway. Skip cheap obviously-not-suspect prefixes
+        // before paying for the resource lookup.
+        if (fOwner.startsWith("net/jonbell/crochet/")) {
+            return false;
+        }
+        Boolean cached = OWNER_SUSPECT_CACHE.get(fOwner);
+        if (cached != null) {
+            return cached.booleanValue();
+        }
+        Boolean resolved = resolveSuspicious(loader, fOwner);
+        if (resolved != null) {
+            OWNER_SUSPECT_CACHE.putIfAbsent(fOwner, resolved);
+            return resolved.booleanValue();
+        }
+        return false;
+    }
+
+    private static Boolean resolveSuspicious(ClassLoader loader, String fOwner) {
+        String resource = fOwner + ".class";
+        ClassLoader effective = loader != null ? loader
+                : FieldAccessWrapper.class.getClassLoader();
+        for (ClassLoader l = effective; l != null; l = l.getParent()) {
+            Boolean r = readSuspectFlags(l, resource);
+            if (r != null) {
+                return r;
+            }
+        }
+        // Fall back to the system classloader for boot-loaded classes that
+        // don't show up via the agent's loader chain.
+        Boolean r = readSuspectFlags(null, resource);
+        return r;
+    }
+
+    private static Boolean readSuspectFlags(ClassLoader l, String resource) {
+        try (java.io.InputStream in = (l != null
+                ? l.getResourceAsStream(resource)
+                : ClassLoader.getSystemResourceAsStream(resource))) {
+            if (in == null) {
+                return null;
+            }
+            org.objectweb.asm.ClassReader reader = new org.objectweb.asm.ClassReader(in);
+            int access = reader.getAccess();
+            if ((access & (Opcodes.ACC_INTERFACE | Opcodes.ACC_ENUM
+                    | Opcodes.ACC_ANNOTATION | Opcodes.ACC_MODULE)) != 0) {
+                return Boolean.TRUE;
+            }
+            String superName = reader.getSuperName();
+            if ("java/lang/Enum".equals(superName)) {
+                return Boolean.TRUE;
+            }
+            return Boolean.FALSE;
+        } catch (java.io.IOException ignored) {
+            return null;
+        } catch (Throwable t) {
+            // A malformed class file or a broken classloader resource lookup
+            // shouldn't abort the whole transform. Fall back to the
+            // INVOKEVIRTUAL fast path.
+            return null;
+        }
     }
 
     private static final class WrapAccessesMV extends CtorAwareMv {
         private final SharedLocalsProvider locals;
+        private final ClassLoader loader;
 
         WrapAccessesMV(int api, MethodVisitor delegate, SharedLocalsProvider locals,
-                       String owner, String superName, boolean isCtor) {
+                       String owner, String superName, boolean isCtor, ClassLoader loader) {
             super(api, delegate, owner, superName, isCtor);
             this.locals = locals;
+            this.loader = loader;
         }
 
         /**
          * Emit the pre-hook for a GETFIELD/PUTFIELD receiver currently on
-         * top of stack: {@code INVOKEVIRTUAL owner.$$crochetAccess()V}.
+         * top of stack.
+         *
+         * <p><b>Fast path (ordinary user class {@code fOwner})</b>:
+         * emit {@code INVOKEVIRTUAL owner.$$crochetAccess()V} directly. This
+         * is the original shape and preserves the JIT devirtualisation the
+         * rest of this javadoc argues for.
+         *
+         * <p><b>Suspicious-owner path ({@code fOwner} is interface/enum/
+         * annotation/module)</b>: these are types {@link CrochetTransformer}
+         * skips — they cannot carry an instance {@code $$crochetAccess}
+         * method, so a direct {@code INVOKEVIRTUAL} fails to link at runtime
+         * with {@code NoSuchMethodError} (gmu-swe/crochet#5). For these
+         * owners we emit a guarded form:
+         *
+         * <pre>
+         *   DUP
+         *   INSTANCEOF CRIJInstrumented
+         *   IFEQ skipLabel
+         *   INVOKEINTERFACE CRIJInstrumented.$$crochetAccess()V
+         *   GOTO endLabel
+         *   skipLabel:
+         *   POP
+         *   endLabel:
+         * </pre>
+         *
+         * The guard costs a handful of extra instructions + a secondary-super
+         * check per emit site — the same cost {@link javadoc} below warns
+         * about — but only on receiver types whose static type already
+         * couldn't host the direct method. The ordinary-class fast path is
+         * unchanged. See {@link FieldAccessWrapper#ownerIsSuspicious} for the
+         * classification predicate.
          *
          * <p><b>Alternative evaluated and reverted:</b> a klass-guarded
          * static call of shape {@code INVOKESTATIC
@@ -104,9 +292,27 @@ public final class FieldAccessWrapper extends ClassVisitor {
          * CRIJFast.isProxy / IFEQ / ...}) was evaluated conceptually but
          * inflates per-site bytecode by ~6 instructions + a stackmap
          * frame — expensive for tradebeans-class-heavy workloads with
-         * &gt;10k emit sites. Not implemented.
+         * &gt;10k emit sites. Not implemented globally, only on the narrow
+         * suspicious-owner path above.
          */
-        private static void emitPreHook(MethodVisitor mv, String fOwner) {
+        private void emitPreHook(MethodVisitor mv, String fOwner) {
+            if (ownerIsSuspicious(loader, fOwner)) {
+                // Guarded form: the caller already DUPed the receiver, so
+                // on entry the stack top is the receiver (the extra copy
+                // we'll consume). See class javadoc for the exact shape.
+                Label skip = new Label();
+                Label after = new Label();
+                mv.visitInsn(Opcodes.DUP);
+                mv.visitTypeInsn(Opcodes.INSTANCEOF, INSTRUMENTED_INTERNAL);
+                mv.visitJumpInsn(Opcodes.IFEQ, skip);
+                mv.visitMethodInsn(Opcodes.INVOKEINTERFACE, INSTRUMENTED_INTERNAL,
+                        "$$crochetAccess", "()V", true);
+                mv.visitJumpInsn(Opcodes.GOTO, after);
+                mv.visitLabel(skip);
+                mv.visitInsn(Opcodes.POP);
+                mv.visitLabel(after);
+                return;
+            }
             mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, fOwner,
                     "$$crochetAccess", "()V", false);
         }

--- a/crochet-agent/src/test/java/net/jonbell/crochet/runtime/FastAccessCoordinatorTest.java
+++ b/crochet-agent/src/test/java/net/jonbell/crochet/runtime/FastAccessCoordinatorTest.java
@@ -24,11 +24,22 @@ class FastAccessCoordinatorTest {
     @Test
     void lockForReturnsStableLock() {
         Object target = new Object();
-        Object a = FastAccessCoordinator.lockFor(target);
-        Object b = FastAccessCoordinator.lockFor(target);
+        FastAccessCoordinator.Stripe a = FastAccessCoordinator.lockFor(target);
+        FastAccessCoordinator.Stripe b = FastAccessCoordinator.lockFor(target);
         assertNotNull(a);
         // identityHashCode is stable so the stripe must be stable too.
         assertSame(a, b);
+        // Stripe must expose a usable ReentrantLock — see Tapestry stripefix
+        // memo on FastAccessCoordinator: the synchronized form deadlocked
+        // when stacked under Fray, so the lock primitive intentionally
+        // routes through LockSupport (via AQS) so Fray can see contention.
+        assertNotNull(a.lock);
+        a.lock.lock();
+        try {
+            assertTrue(a.lock.isHeldByCurrentThread());
+        } finally {
+            a.lock.unlock();
+        }
     }
 
     @Test
@@ -38,11 +49,12 @@ class FastAccessCoordinatorTest {
         // targets map to at least some diversity of stripes. Collision rate
         // under an ideal mixer is ~count/stripes.
         int samples = 10_000;
-        java.util.IdentityHashMap<Object, Integer> stripeIds = new java.util.IdentityHashMap<>();
+        java.util.IdentityHashMap<FastAccessCoordinator.Stripe, Integer> stripeIds =
+                new java.util.IdentityHashMap<>();
         int distinctStripes = 0;
         for (int i = 0; i < samples; i++) {
             Object o = new Object();
-            Object stripe = FastAccessCoordinator.lockFor(o);
+            FastAccessCoordinator.Stripe stripe = FastAccessCoordinator.lockFor(o);
             if (stripeIds.putIfAbsent(stripe, i) == null) {
                 distinctStripes++;
             }

--- a/demo/run-all.sh
+++ b/demo/run-all.sh
@@ -8,11 +8,16 @@
 set -u
 cd "$(dirname "$0")"
 
-AGENT_JAR="$(cd .. && pwd)/crochet-agent/target/crochet-agent-1.0.0-SNAPSHOT.jar"
-if [ ! -f "$AGENT_JAR" ]; then
+# Resolve the agent jar by glob so we don't have to hard-code the snapshot
+# version (the Maven coords on the java24-port branch carry a tapestry-* tag
+# which changes per integration round).
+AGENT_GLOB="$(cd .. && pwd)/crochet-agent/target/crochet-agent-*.jar"
+AGENT_JAR=$(ls -t $AGENT_GLOB 2>/dev/null | head -1 || true)
+if [ -z "${AGENT_JAR:-}" ] || [ ! -f "$AGENT_JAR" ]; then
     echo "Building crochet-agent..."
     (cd .. && PATH=~/.local/bin:$PATH mvn -q -pl :crochet-agent package -DskipTests) || {
         echo "FAIL: build"; exit 1; }
+    AGENT_JAR=$(ls -t $AGENT_GLOB 2>/dev/null | head -1)
 fi
 
 USE_INSTRUMENTED=0

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
 
-        <asm.version>9.7.1</asm.version>
+        <asm.version>9.9</asm.version>
         <junit.version>5.11.3</junit.version>
 
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>


### PR DESCRIPTION
This PR bundles three independent fixes that surfaced while integrating Crochet's `-javaagent` underneath another bytecode-rewriting agent (Fray, in the [Tapestry](https://github.com/<TBD>/tapestry) research prototype). All three fixes also stand on their own merits — the ASM bump is needed for any Java 25-targeted workload, the enum-receiver fix is a latent correctness bug not specific to agent stacking, and the stripe-lock change preserves identical lock semantics while also being instrumentable.

**Branch builds clean (`mvn install -DskipTests`); 35/35 unit tests pass; 20/20 demo scenarios pass on a fresh instrumented JDK.**

## Commit-by-commit

### 1. `015a721` — bump ASM 9.7.1 → 9.9 for Java 25 class file (v69) support
ASM 9.7.1's `ClassReader` rejects class files with major version > 67. Java 24/25 (v68/v69) workloads fail to load through the agent with `IllegalArgumentException: Unsupported class file major version 69`. ASM 9.9 (Jan 2026) adds V24/V25/V26 in `Opcodes`. The transformer chain still uses the ASM9 API level — no other adjustment needed.

### 2. `136e24d` — fix NoSuchMethodError on enum/interface receivers (#5)
Closes #5. `CrochetTransformer` skips `ACC_ENUM` / `ACC_INTERFACE` / `ACC_ANNOTATION` / `ACC_MODULE` classes (and direct enum-constant subclasses) because the JVM rejects instance-field/method injection on those forms. But `FieldAccessWrapper.emitPreHook` unconditionally emitted `INVOKEVIRTUAL <fOwner>.$$crochetAccess()V`, which fails to link when `fOwner` is one of the skipped forms.

Real-world repros: `kotlinx.serialization.json.internal.WriteMode` (Kotlin enum) and `org.slf4j.helpers.Reporter\$Level` (Java enum). Both fail with `NoSuchMethodError` on baseline; pass after the fix.

The fix emits a guarded form on suspicious owners (`DUP / INSTANCEOF CRIJInstrumented / IFEQ skip / INVOKEINTERFACE \$\$crochetAccess / GOTO end / skip: POP / end:`) while keeping the direct `INVOKEVIRTUAL` fast path for ordinary user-class owners. Owner classification reads access flags via `ClassLoader.getResourceAsStream` + `ClassReader` — never `Class.forName` (which from inside a `ClassFileTransformer` either bypasses our transformer for the recursive load or deadlocks on the loader monitor). Per-owner-name cache.

### 3. `63d3675` — replace stripe-lock JVM monitor with ReentrantLock for instrumentation visibility
`FastAccessCoordinator` stripes used to be plain `Object` instances locked via `synchronized (stripe) { ... }`. That works on plain Crochet but deadlocks when the agent is stacked under another bytecode rewriter that wraps `monitorenter` (Fray; presumably similar with Lincheck, JESS, JMVx, etc.).

Mechanism: Crochet's premain transitively forces `FastProxySupport` and `FastAccessCoordinator` to load eagerly during `-javaagent:crochet.jar` install. If a second `-javaagent` is listed later, its premain runs strictly after Crochet's; by the time it adds its `MonitorInstrumenter`, Crochet's runtime classes are already loaded. Standard `addTransformer` doesn't re-instrument loaded classes (callers would need `retransformClasses`), so the `monitorenter` in `fastAccess` stays uninstrumented. The downstream scheduler then can't see contention on the stripe and deadlocks.

`ReentrantLock` side-steps this: its lock body is in `java.util.concurrent.locks` (`java.base`), and the contended path runs through `LockSupport.park()` — which any sane downstream scheduler agent already wraps. Lock semantics are happens-before equivalent (JLS §17.4.5), reentrancy is preserved, padding via `@Contended` still applies. Microbench shows identical uncontended cost (single CAS on AQS state, same as biased-monitor inflation bits) and within-noise contended cost.

The same commit also documents two paper §3.1 semantics on `CheckpointRollbackAgent.checkpointAll` that weren't in the API doc and tripped up at least one downstream user: (a) `checkpointAll` snaps only static-field reference *values*, not referent state — explicit `checkpoint(obj)` is needed; (b) each checkpoint/rollback pair is one-shot per phase — re-checkpoint between iterations.

### 4. `07904ec` — `demo/run-all.sh`: glob the agent jar instead of hard-coding the snapshot version
Bookkeeping. Lets the demo script keep working when the snapshot tag in the parent pom changes during integration work.

## Verification

- `mvn -pl crochet-agent test`: **35/35** PASS (including `FastAccessCoordinatorTest` updated for the `Stripe` return type)
- `crochet/demo/run-all.sh` baseline: **20/20** PASS
- `crochet/demo/run-all.sh --instrumented` (against a fresh `/tmp/jdk-inst-stripefix`): **20/20** PASS
- Tapestry integration tests under stacked Fray + Crochet (`SetupAmortizationIT` + `BugDetectionIT`): both PASS
- Lucene-5K Tapestry mode: per-iter median 15.5 ms (within prior 12-15 ms range; no perf regression)
- Kafka Streams workload (`KafkaStreams` constructor + concurrent `close()` race) under stacked instrumentation: previously hung indefinitely on stripe-lock deadlock, now completes in ~10 s wall-clock for 3 iterations

## Notes for the maintainer

- The version in `pom.xml` is unchanged at `1.0.0-SNAPSHOT` — release versioning is yours to pick.
- I have NOT attempted the lock-free CAS state machine alternative discussed in `FieldAccessWrapper.emitPreHook`'s javadoc. `ReentrantLock` is uncontended-equivalent and gives reentrancy for free; the propagate-checkpoint/rollback paths can re-enter `fastAccess` on objects that hash to the same stripe, which the JVM monitor permitted implicitly.
- The Tapestry integration also surfaced an unrelated Fray scheduler bug (`ObjectWakeBlocked` vs `ThreadResumeOperation` `ClassCastException` in `RunContext.objectWaitDoneImpl` during Kafka Streams `close()`) that I'll report upstream to Fray separately. It's not blocking — the deadlock that motivated commit 3 is gone — but worth flagging if you see it in your own testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)